### PR TITLE
Add Option for using the Coingecko Pro Api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,16 @@
         "test:unit": "pest --colors=always",
         "test": ["@test:lint", "@test:refacto", "@test:types", "@test:unit"]
     },
+    "extra": {
+        "laravel": {
+          "providers": [
+            "Musheabdulhakim\\CoinGecko\\ServiceProviders\\CoinGeckoServiceProvider"
+          ],
+          "aliases": {
+            "CoinGecko": "Musheabdulhakim\\CoinGecko\\Facades\\CoinGecko"
+          }
+        }
+      },
     "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/src/CoinGecko.php
+++ b/src/CoinGecko.php
@@ -37,7 +37,7 @@ final class CoinGecko
     }
 
     /**
-     * Creates a new factory instance to configure a custom Open AI Client
+     * Creates a new factory instance to configure a custom Client
      */
     public static function factory(): Factory
     {

--- a/src/CoinGecko.php
+++ b/src/CoinGecko.php
@@ -17,22 +17,14 @@ final class CoinGecko
             ->withApiKey($apiKey);
     }
 
-    public static function client(string $apiKey, string $baseUri = '', string $version = ''): Client
+    public static function client(string $apiKey = '', string $baseUri = '', bool $isPro = false, string $version = ''): Client
     {
-        $apiBaseUri = '';
-        if ($baseUri !== '') {
-            $apiBaseUri = $baseUri;
-        }
-
-        $apiVersion = '';
-        if ($version !== '') {
-            $apiVersion = $version;
-        }
 
         return self::factory()
-            ->withBaseUri($apiBaseUri)
             ->withApiKey($apiKey)
-            ->withVersion($apiVersion)
+            ->withBaseUri($baseUri)
+            ->withPro($isPro)
+            ->withVersion($version)
             ->make();
     }
 

--- a/src/Config/coingecko.php
+++ b/src/Config/coingecko.php
@@ -31,4 +31,10 @@ return [
      */
     'COINGECKO_API_KEY' => '',
 
+    /**
+     * Set to true if you are using the pro version
+     * When this is set to true, make sure the base uri is also set to the pro api url
+     */
+    'COINGECKO_PRO' => false,
+
 ];

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -32,10 +32,10 @@ final readonly class Headers
     /**
      * Creates a new Headers value object with the given API token.
      */
-    public static function withAuthorization(ApiKey $apiKey): self
+    public static function withAuthorization(bool $isPro, ApiKey $apiKey): self
     {
         return new self([
-            'x-cg-pro-api-key' => "{$apiKey->toString()}",
+            !empty($isPro) && ($isPro === true) ? 'x-cg-pro-api-key' : 'x-cg-demo-api-key' => "{$apiKey->toString()}",
         ]);
     }
 


### PR DESCRIPTION
The following features  has been added.
- laravel service provider support
- Support for using either the pro api or the free version

You can now pass a boolean to the client method to specify whether to use the pro api or just the free version.
```
$coingecko = \MusheAbdulHakim\CoinGecko\CoinGecko::client('your-api-key','pro_api_url', true, 'v3');
```
By passing true to the client, you will be able to use the pro api endpoints